### PR TITLE
Hosting choromap-lite into our huq-choromap-lite GCS bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,10 @@ A GitHub repository for all community visualisations made by the Data Science Ca
 - [choromap-lite (a lite version of the choropleth mapping tool)](https://github.com/datasciencecampus/community-visualizations/tree/main/choromap-lite)
 - [violin (a violin plotting tool)](https://github.com/datasciencecampus/community-visualizations/tree/main/violin)
 - [flight-paths (animated, connected scatter plots)](https://github.com/datasciencecampus/community-visualizations/tree/main/flight-paths)
+
+## Huq Industries Hosting
+
+The Huq Industries hosted version of this visualization are published at:
+- choromap-lite: gs://huq-choromap-lite.
+
+To update the code we have to copy the content of [choromap-lite/src/](choromap-lite/src/) into the bucket. **Note** that manifest changes will require to re-allow the visualization in each report.

--- a/choromap-lite/src/manifest.json
+++ b/choromap-lite/src/manifest.json
@@ -1,23 +1,23 @@
 {
-  "name": "Choropleth Map (lite)",
-  "logoUrl": "https://storage.googleapis.com/choromap-lite/choropleth.png",
-  "organization": "Data Science Campus",
+  "name": "Choropleth Map (lite). Hosted by Huq Industries.",
+  "logoUrl": "https://storage.googleapis.com/huq-choromap-lite/choropleth.png",
+  "organization": "Data Science Campus (hosted by Huq Industries)",
   "organizationUrl": "https://datasciencecampus.ons.gov.uk/",
   "supportUrl": "https://github.com/datasciencecampus/community-visualizations/issues",
   "packageUrl": "https://datastudio.google.com/reporting/d0c938d0-9e49-4781-8cab-ec159c233499/page/XEHUB",
   "privacyPolicyUrl": "https://datasciencecampus.github.io/community-visualizations/docs/privacy-policy.html",
-  "description": "Choropleth mapping for Google Data Studio written in D3 (lite)",
+  "description": "Choropleth mapping for Google Data Studio written in D3 (lite). Hosted by Huq Industries.",
   "devMode": true,
   "termsOfServiceUrl": "https://datasciencecampus.github.io/community-visualizations/docs/privacy-policy.html",
   "components": [{
-    "id": "choromap-lite",
+    "id": "huq-choromap-lite",
     "name": "Choropleth Map (lite)",
-    "iconUrl": "https://storage.googleapis.com/choromap-lite/choropleth.png",
-    "description": "Choropleth mapping for Google Data Studio written in D3 (lite).",
+    "iconUrl": "https://storage.googleapis.com/huq-choromap-lite/choropleth.png",
+    "description": "Choropleth mapping for Google Data Studio written in D3 (lite). Hosted by Huq Industries.",
     "resource": {
-      "js": "gs://choromap-lite/choromap.js",
-      "config": "gs://choromap-lite/choromap.json",
-      "css": "gs://choromap-lite/choromap.css"
+      "js": "gs://huq-choromap-lite/choromap.js",
+      "config": "gs://huq-choromap-lite/choromap.json",
+      "css": "gs://huq-choromap-lite/choromap.css"
     }
   }]
 }


### PR DESCRIPTION
Changes to clarify which version is hosted by us.