### PR TITLE
Add apply fitler feature for choromap-lite

### DIFF
--- a/choromap-lite/src/choromap.json
+++ b/choromap-lite/src/choromap.json
@@ -404,5 +404,11 @@
         }
       ]
     }
+  ],
+  "interactions": [
+    {
+      "id": "onClick",
+      "supportedActions": ["FILTER"]
+    }
   ]
 }


### PR DESCRIPTION
These changes provide an initial implementation of the "apply filter" feature for the choromap-lite d3.js tool. The apply filter feature enables a Google Data Studio visualization to act as an interactive filter control for other charts on the report page.

**Function:** This feature is enabled when "Apply Filter" is selected in the "DATA" panel under the "Interactions" section. An onclick event allows the user to select or unselect a region/dimension value to use as a filter control. 

**Style**: The opacity is lowered to 30% for regions that are not selected so as to 'highlight' the selected region.

