### PR TITLE
Fixing id conflicts and default values

### DIFF
--- a/choromap/src/choromap.js
+++ b/choromap/src/choromap.js
@@ -17711,9 +17711,9 @@ const drawViz = data => {
     ? data.style.legendTextFamily.value
     : data.style.legendTextFamily.defaultValue;
 
-    var boundary =  data.style.boundary.value
-    ? data.style.boundary.value
-    : data.style.boundary.defaultValue;
+    var boundaryGeoJSON =  data.style.boundaryGeoJSON.value
+    ? data.style.boundaryGeoJSON.value
+    : data.style.boundaryGeoJSON.defaultValue;
 
     var boundaryBorderColor =  data.style.boundaryBorderColor.value
     ? data.style.boundaryBorderColor.value.color
@@ -17730,9 +17730,9 @@ const drawViz = data => {
     var height = dscc.getHeight();
 
     // Create boundary geoJSON object if user specifies they want to plot one in STYLE
-    if (boundary != "Add boundary geojson here"){
+    if (boundaryGeoJSON != "Add boundary geojson here"){
 
-        var boundary = JSON.parse(boundary)
+        var boundaryGeoJSON = JSON.parse(boundaryGeoJSON)
 
     }
 
@@ -17903,13 +17903,13 @@ const drawViz = data => {
             var decimalSuffix = 's'
         }
 
-        if (boundary != "Add boundary geojson here" && zoomOnFilter == "No"){
+        if (boundaryGeoJSON != "Add boundary geojson here" && zoomOnFilter == "No"){
             // Finds centroid of path for plotting
-            var centroid = path.centroid(boundary)
+            var centroid = path.centroid(boundaryGeoJSON)
             // Sets projection
             var projection = d3['geo' + projectionSelection]()
                 .center(centroid)
-                .fitExtent([[projectionCenterLon,projectionCenterLat],[width, height - 25]], boundary);
+                .fitExtent([[projectionCenterLon,projectionCenterLat],[width, height - 25]], boundaryGeoJSON);
         } else {
             // Finds centroid of path for plotting
             var centroid = path.centroid(geojson)
@@ -17986,10 +17986,10 @@ const drawViz = data => {
         };
 
         // Draw the boundary if user specifies they want one in STYLE
-        if (boundary != "Add boundary geojson here"){
+        if (boundaryGeoJSON != "Add boundary geojson here"){
             var b = svg.append("g")
                 .selectAll("path")
-                    .data(boundary.features)
+                    .data(boundaryGeoJSON.features)
                     .enter()
                     .append("path")
                     // Draw each polygon as a path

--- a/choromap/src/choromap.json
+++ b/choromap/src/choromap.json
@@ -129,13 +129,13 @@
           "type": "TEXTINPUT",
           "id": "projectionCenterLon",
           "label": "Center Lon",
-          "defaultValue": 0
+          "defaultValue": "0"
         },
         {
           "type": "TEXTINPUT",
           "id": "projectionCenterLat",
           "label": "Center Lat",
-          "defaultValue": 0
+          "defaultValue": "0"
         },
         {
           "type": "TEXTINPUT",
@@ -195,7 +195,7 @@
           "type": "TEXTINPUT",
           "id": "polygonBorderWidth",
           "label": "Polygon Border Width",
-          "defaultValue": 0
+          "defaultValue": "0"
         }
       ]
     },
@@ -259,7 +259,7 @@
           "type": "TEXTINPUT",
           "id": "legendCells",
           "label": "Number of Quantiles / Categories",
-          "defaultValue": 5
+          "defaultValue": "5"
         },
         {
           "type": "TEXTINPUT",
@@ -277,7 +277,7 @@
           "type": "TEXTINPUT",
           "id": "legendDecimalPlaces",
           "label": "Decimal Places",
-          "defaultValue": 0
+          "defaultValue": "0"
         },
         {
           "type": "SELECT_SINGLE",
@@ -356,7 +356,7 @@
           "type": "TEXTINPUT",
           "id": "boundaryBorderWidth",
           "label": "Boundary Border Width",
-          "defaultValue": 0
+          "defaultValue": "0"
         },
         {
           "type": "SELECT_SINGLE",

--- a/choromap/src/choromap.json
+++ b/choromap/src/choromap.json
@@ -342,7 +342,7 @@
       "elements": [
         {
           "type": "TEXTINPUT",
-          "id": "boundary",
+          "id": "boundaryGeoJSON",
           "label": "Input boundary GeoJSON",
           "defaultValue": "Add boundary geojson here"
         },


### PR DESCRIPTION
I have added two fixes in this PR for issues that I have recently seen:

- First issue was that there were two ids called boundary, one for the section and one for the boundary Geo JSON field and it looks like that was causing a conflict not displaying anymore the boundary Geo JSON field and not assigning the default value, so the whole system was not working. The provided solution simply renames the field to get a different id and varible name (boundaryGeoJSON instead of boundary)
- When loading the interface I could also see errors because of having integers as default values for text fields and I updated them to contain the string value.

Hope this can make the plugin works again!

Thank you!